### PR TITLE
Support only switching to tabs in the same window

### DIFF
--- a/mainsw.js
+++ b/mainsw.js
@@ -128,25 +128,35 @@ var doIntSwitch = function() {
 		} else {
 			incrementSwitchCounter();	
 		}
-		tabIdToMakeActive = mru[intSwitchCount];
-		chrome.tabs.get(tabIdToMakeActive, function(tab) {
-			if(tab) {
-				thisWindowId = tab.windowId;
-				invalidTab = false;
-
-				chrome.windows.update(thisWindowId, {"focused":true});
-				chrome.tabs.update(tabIdToMakeActive, {active:true, highlighted: true});
-				lastIntSwitchIndex = intSwitchCount;
-				//break;
-			} else {
-				CLUTlog("CLUT:: in int switch, >>invalid tab found.intSwitchCount: "+intSwitchCount+", mru.length: "+mru.length);
-				removeItemAtIndexFromMRU(intSwitchCount);
-				if(intSwitchCount >= mru.length) {
-					intSwitchCount = 0;
-				}
-				doIntSwitch();
+		chrome.tabs.query({lastFocusedWindow: true, active: true}, function(activeTabs) {
+			var activeTab = activeTabs[0];
+			if (!activeTab) {
+				return;
 			}
-		});	
+			tabIdToMakeActive = mru[intSwitchCount];
+			chrome.tabs.get(tabIdToMakeActive, function(tab) {
+				if(tab) {
+					if (tab.windowId !== activeTab.windowId || tab.id === activeTab.id) {
+						doIntSwitch();
+					} else {
+						thisWindowId = tab.windowId;
+						invalidTab = false;
+
+						chrome.windows.update(thisWindowId, {"focused":true});
+						chrome.tabs.update(tabIdToMakeActive, {active:true, highlighted: true});
+						lastIntSwitchIndex = intSwitchCount;
+						//break;
+					}
+				} else {
+					CLUTlog("CLUT:: in int switch, >>invalid tab found.intSwitchCount: "+intSwitchCount+", mru.length: "+mru.length);
+					removeItemAtIndexFromMRU(intSwitchCount);
+					if(intSwitchCount >= mru.length) {
+						intSwitchCount = 0;
+					}
+					doIntSwitch();
+				}
+			});
+		});
 
 		
 	}

--- a/mainsw.js
+++ b/mainsw.js
@@ -18,6 +18,7 @@ var timer;
 var slowswitchForward = false;
 
 var initialized = false;
+var options = {};
 
 var loggingOn = false;
 
@@ -130,13 +131,13 @@ var doIntSwitch = function() {
 		}
 		chrome.tabs.query({lastFocusedWindow: true, active: true}, function(activeTabs) {
 			var activeTab = activeTabs[0];
-			if (!activeTab) {
+			if (options.onlySameWindow && !activeTab) {
 				return;
 			}
 			tabIdToMakeActive = mru[intSwitchCount];
 			chrome.tabs.get(tabIdToMakeActive, function(tab) {
 				if(tab) {
-					if (tab.windowId !== activeTab.windowId || tab.id === activeTab.id) {
+					if (options.onlySameWindow && (tab.windowId !== activeTab.windowId || tab.id === activeTab.id)) {
 						doIntSwitch();
 					} else {
 						thisWindowId = tab.windowId;
@@ -260,6 +261,18 @@ var initialize = function() {
 				});
 			});
 			CLUTlog("MRU after init: "+mru);
+		});
+
+		chrome.storage.sync.get({
+			onlySameWindow: false
+		}, function(items) {
+			options.onlySameWindow = items.onlySameWindow;
+		});
+
+		chrome.storage.onChanged.addListener(function (changes) {
+			for (let [key, { newValue }] of Object.entries(changes)) {
+				options[key] = newValue;
+			}
 		});
 	}
 }	

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "short_name": "CLUT",
 
   "permissions": [
-    "tabs"
+    "tabs",
+    "storage"
   ],
   "icons": {
     "16": "icon16.png",
@@ -42,5 +43,9 @@
   },
   "action": {
     "default_icon": "icon16.png"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
   }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head><title>CLUT Options</title></head>
+<body>
+
+<label>
+	<input type="checkbox" id="only-same-window">
+	Only switch to tabs in the same window
+</label>
+
+<div id="status"></div>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,27 @@
+// Saves options to chrome.storage
+function save_options() {
+	var onlySameWindow = document.getElementById('only-same-window').checked;
+	chrome.storage.sync.set({
+		onlySameWindow
+	}, function() {
+		// Update status to let user know options were saved.
+		var status = document.getElementById('status');
+		status.textContent = 'Options saved.';
+		setTimeout(function() {
+			status.textContent = '';
+		}, 750);
+	});
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+	// Use default value color = 'red' and likesColor = true.
+	chrome.storage.sync.get({
+		onlySameWindow: false
+	}, function(items) {
+		document.getElementById('only-same-window').checked = items.onlySameWindow;
+	});
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
This adds an option which when enabled makes the actions only switch to tabs in the same window. If the option is disabled (the default), it behaves the same as before.